### PR TITLE
OpenBSD portability: BSD stack-size introspection + CI gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -341,3 +341,36 @@ jobs:
         run: cmake --build build -j 4
       - name: Smoke test
         run: build/rakupp tools/smoke.raku
+
+  # OpenBSD portability gate. GitHub has no native BSD runner, so vmactions boots
+  # a real OpenBSD guest under QEMU inside the Ubuntu runner and runs the build
+  # in it. OpenBSD's base `c++` is clang + libc++ (no libstdc++), so no static
+  # portability flags here. The one non-obvious trap: OpenBSD's default login-
+  # class `datasize` limit is low enough that an -O3 C++ compile can be killed
+  # for exhausting memory — `ulimit -d` lifts it before configuring.
+  openbsd-portability:
+    name: openbsd (build + smoke)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build & test on OpenBSD
+        uses: vmactions/openbsd-vm@v1
+        with:
+          usesh: true
+          # cmake + gmake: CMake's Unix Makefiles generator needs GNU make on
+          # BSD; `cmake --build` then drives gmake. clang/clang++ are in base.
+          prepare: |
+            pkg_add -I cmake gmake
+          run: |
+            set -e
+            ulimit -d 2097152 || true   # raise datasize so the compile isn't OOM-killed
+            cc --version
+            cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+            cmake --build build -j 2
+            build/rakupp tools/smoke.raku
+            out=$(build/rakupp -e 'say 6 * 7')
+            echo "got: [$out]"
+            test "$out" = "42"
+            # --exe end-to-end: compiles generated C++ with the base clang toolchain
+            build/rakupp --exe tools/smoke.raku -o smoke-native
+            ./smoke-native

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -35,6 +35,10 @@ static char** rakupp_environ() { return environ; }
 #if !defined(_WIN32)
 #include <dirent.h>   // Windows gets the FindFirstFile-based shim from Platform.h
 #endif
+#if defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+#include <signal.h>      // stack_t (used by pthread_stackseg_np's out-param)
+#include <pthread_np.h>  // pthread_stackseg_np (OpenBSD) / pthread_attr_get_np (Free/Net/DragonFly)
+#endif
 
 namespace rakupp {
 
@@ -4045,6 +4049,20 @@ static size_t currentThreadStackSize() {
     return sz ? sz : (size_t(8) << 20);
 #elif defined(__APPLE__)
     size_t sz = pthread_get_stacksize_np(pthread_self());
+    return sz ? sz : (size_t(8) << 20);
+#elif defined(__OpenBSD__)
+    // OpenBSD has no pthread_getattr_np; pthread_stackseg_np fills a stack_t
+    // whose ss_size is the thread's stack size (glibc extension by another name).
+    stack_t ss; size_t sz = 0;
+    if (pthread_stackseg_np(pthread_self(), &ss) == 0) sz = ss.ss_size;
+    return sz ? sz : (size_t(8) << 20);
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+    // These BSDs spell it pthread_attr_get_np, and the attr must be init'd first.
+    pthread_attr_t attr; void* base = nullptr; size_t sz = 0;
+    pthread_attr_init(&attr);
+    if (pthread_attr_get_np(pthread_self(), &attr) == 0)
+        pthread_attr_getstack(&attr, &base, &sz);
+    pthread_attr_destroy(&attr);
     return sz ? sz : (size_t(8) << 20);
 #else
     pthread_attr_t attr; void* base = nullptr; size_t sz = 0;


### PR DESCRIPTION
## Context

A build report from OpenBSD 7.9 (Clang 19) surfaced two issues. Only one is ours:

1. **`-fsanitize=address,undefined` configure failure** — *not* a repo bug. The flags come from the reporter's environment (`CXXFLAGS`/`LDFLAGS`), not from `CMakeLists.txt` (which is why their `grep sanitize` found nothing). No change needed here.
2. **`pthread_getattr_np` compile failure** — a real portability bug, fixed here.

## The fix

`currentThreadStackSize()` (feeds the recursion guard that turns deep Raku recursion into a clean `X::Recursion` instead of SIGSEGV) had a Windows branch, an Apple branch, and an `#else` that assumed **glibc**'s `pthread_getattr_np`. OpenBSD's libc has no such function, so the interpreter didn't compile there.

Added proper BSD branches:
- **OpenBSD** → `pthread_stackseg_np(pthread_self(), &ss)` → `ss.ss_size`
- **FreeBSD / NetBSD / DragonFly** → `pthread_attr_get_np` (attr init'd first)
- guarded `#include <pthread_np.h>` / `<signal.h>`
- both keep the existing 8 MiB fallback if the query fails

## CI

New `openbsd-portability` job (`vmactions/openbsd-vm`) boots a real OpenBSD guest under QEMU in the Ubuntu runner and runs build + smoke + `--exe`, so BSD regressions surface on push/PR — same role as the existing `gcc-portability` gate. It raises the `datasize` ulimit first (OpenBSD's default login-class limit can OOM-kill an `-O3` C++ compile).

## Verified

Clean macOS build + smoke test pass. The OpenBSD job in this PR will be the real cross-platform confirmation (and will catch any *further* BSD-isms beyond this first file).