### PR TITLE
Allow building rakupp using Gnu Guix

### DIFF
--- a/.guix-channel
+++ b/.guix-channel
@@ -1,0 +1,3 @@
+(channel
+  (version 0)
+  (directory ".guix/modules"))

--- a/.guix/modules/rakupp-package.scm
+++ b/.guix/modules/rakupp-package.scm
@@ -5,25 +5,20 @@
   #:use-module (guix build-system cmake)
   #:use-module ((guix licenses) #:prefix license:))
 
-(package
- (name "rakupp")
- (version "1.2.0")
- (source (origin
-          (method git-fetch)
-          (uri (git-reference
-                (url "https://github.com/ash/rakupp")
-                (commit "main")))
-          (file-name (git-file-name name version))
-          (sha256
-           (base32
-            "1w4sr6d5fag1a4n9yaavi0ihvizr0prf6050g8mlqfrx5wsrzqm3"))))
- (build-system cmake-build-system)
- (arguments
-  (list 
-   #:build-type "Release"
-   #:tests? #f))
- (synopsis "Raku++ — a Raku language interpreter and compiler written from scratch in C++17, validated against the Roast spec suite.")
- (description
-  "A from-scratch implementation of the Raku programming language in C++17, with no third-party dependencies — a hand-written lexer, parser, and tree-walking evaluator that runs real Raku (classes, roles, grammars, regexes, multi-dispatch, junctions, lazy sequences, a bignum tower, Unicode-correct strings, and concurrency), can also compile a program to a standalone native binary, and — as Raku.js — runs in the browser via WebAssembly, no server required. It is not a fork of Rakudo and shares no code with it; it targets the language, measured against Roast, the official Raku test suite.")
- (home-page "https://github.com/ash/rakupp")
- (license license:artistic2.0))
+(define-public rakupp
+  (package
+   (name "rakupp")
+   (version "1.2.0-git")
+   (source (local-file "../.." "rakupp-checkout"
+                       #:recursive? #t
+                       #:select? vcs-file?))
+   (build-system cmake-build-system)
+   (arguments
+    (list 
+     #:build-type "Release"
+     #:tests? #f))
+   (synopsis "Raku++ — a Raku language interpreter and compiler written from scratch in C++17, validated against the Roast spec suite.")
+   (description
+    "A from-scratch implementation of the Raku programming language in C++17, with no third-party dependencies — a hand-written lexer, parser, and tree-walking evaluator that runs real Raku (classes, roles, grammars, regexes, multi-dispatch, junctions, lazy sequences, a bignum tower, Unicode-correct strings, and concurrency), can also compile a program to a standalone native binary, and — as Raku.js — runs in the browser via WebAssembly, no server required. It is not a fork of Rakudo and shares no code with it; it targets the language, measured against Roast, the official Raku test suite.")
+   (home-page "https://github.com/ash/rakupp")
+   (license license:artistic2.0)))

--- a/.guix/modules/rakupp-package.scm
+++ b/.guix/modules/rakupp-package.scm
@@ -1,4 +1,5 @@
 (define-module (rakupp-package)
+  #:use-module (guix)
   #:use-module (guix packages)
   #:use-module (guix gexp)
   #:use-module (guix git-download)
@@ -27,3 +28,5 @@
     "A from-scratch implementation of the Raku programming language in C++17, with no third-party dependencies — a hand-written lexer, parser, and tree-walking evaluator that runs real Raku (classes, roles, grammars, regexes, multi-dispatch, junctions, lazy sequences, a bignum tower, Unicode-correct strings, and concurrency), can also compile a program to a standalone native binary, and — as Raku.js — runs in the browser via WebAssembly, no server required. It is not a fork of Rakudo and shares no code with it; it targets the language, measured against Roast, the official Raku test suite.")
    (home-page "https://github.com/ash/rakupp")
    (license license:artistic2.0)))
+
+rakupp

--- a/.guix/modules/rakupp-package.scm
+++ b/.guix/modules/rakupp-package.scm
@@ -1,0 +1,29 @@
+(define-module (rakupp-package)
+  #:use-module (guix packages)
+  #:use-module (guix gexp)
+  #:use-module (guix git-download)
+  #:use-module (guix build-system cmake)
+  #:use-module ((guix licenses) #:prefix license:))
+
+(package
+ (name "rakupp")
+ (version "1.2.0")
+ (source (origin
+          (method git-fetch)
+          (uri (git-reference
+                (url "https://github.com/ash/rakupp")
+                (commit "main")))
+          (file-name (git-file-name name version))
+          (sha256
+           (base32
+            "1w4sr6d5fag1a4n9yaavi0ihvizr0prf6050g8mlqfrx5wsrzqm3"))))
+ (build-system cmake-build-system)
+ (arguments
+  (list 
+   #:build-type "Release"
+   #:tests? #f))
+ (synopsis "Raku++ — a Raku language interpreter and compiler written from scratch in C++17, validated against the Roast spec suite.")
+ (description
+  "A from-scratch implementation of the Raku programming language in C++17, with no third-party dependencies — a hand-written lexer, parser, and tree-walking evaluator that runs real Raku (classes, roles, grammars, regexes, multi-dispatch, junctions, lazy sequences, a bignum tower, Unicode-correct strings, and concurrency), can also compile a program to a standalone native binary, and — as Raku.js — runs in the browser via WebAssembly, no server required. It is not a fork of Rakudo and shares no code with it; it targets the language, measured against Roast, the official Raku test suite.")
+ (home-page "https://github.com/ash/rakupp")
+ (license license:artistic2.0))

--- a/.guix/modules/rakupp-package.scm
+++ b/.guix/modules/rakupp-package.scm
@@ -22,6 +22,7 @@
    (arguments
     (list 
      #:build-type "Release"
+     #:configure-flags #~(list "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
      #:tests? #f))
    (synopsis "Raku++ — a Raku language interpreter and compiler written from scratch in C++17, validated against the Roast spec suite.")
    (description

--- a/.guix/modules/rakupp-package.scm
+++ b/.guix/modules/rakupp-package.scm
@@ -5,6 +5,11 @@
   #:use-module (guix build-system cmake)
   #:use-module ((guix licenses) #:prefix license:))
 
+(define vcs-file?
+  ;; Return true if the given file is under version control.
+  (or (git-predicate (current-source-directory))
+      (const #t)))
+
 (define-public rakupp
   (package
    (name "rakupp")


### PR DESCRIPTION
Guix users would simply need to add this repo in their channel like this:
```scm
(channel
  (name 'rakupp)
  (url "https://github.com/4zv4l/rakupp")
  (branch "main"))
```
And would be able to build/install rakupp.